### PR TITLE
Updated citation to use and instead of comma.

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -27,7 +27,7 @@ Please refer to our website at [graphlearning.io](http://www.graphlearning.io/) 
 ```
 @misc{KKMMN2016,
   title  = {TUDataset: A collection of benchmark datasets for learning with graphs},
-  author = {Christopher Morris,  Nils M. Kriege, Franka Bause, Kristian Kersting, Petra Mutzel, Marion Neumann},
+  author = {Christopher Morris and  Nils M. Kriege and Franka Bause and Kristian Kersting and Petra Mutzel and Marion Neumann},
   year   = {2020},
   url    = {http://www.graphlearning.io/}
 }


### PR DESCRIPTION
Hi,

cool project. While using your citation, I noted that you use commas to separate names in the author field. In BibTeX, commas are for seperating surname and forename, to separate different authors, you should use `and`. See als https://tex.stackexchange.com/questions/343163/error-in-bib-entry-too-many-commas

Best Wishes,
Nicholas