### PR TITLE
Fix stats: Graph counts, node and edge averages

### DIFF
--- a/_docs/datasets.md
+++ b/_docs/datasets.md
@@ -17,46 +17,46 @@ permalink: /docs/datasets/
 |**BZR_MD**|[7,23]| 306 |2|21.30|225.06|+|+|--|--|+ (1)|[BZR_MD](https://www.chrsmrrs.com/graphkerneldatasets/BZR_MD.zip)|
 |**COX2**|[7]| 467 |2|41.22 |43.45|+|--|+ (3)|3D, RI|--|[COX2](https://www.chrsmrrs.com/graphkerneldatasets/COX2.zip)|
 |**COX2_MD**|[7,23]| 303 |2|26.28|335.12|+|+|--|--|+ (1)|[COX2_MD](https://www.chrsmrrs.com/graphkerneldatasets/COX2_MD.zip)|
-|**DHFR**|[7]| 467 |2|42.43|44.54|+|--|+ (3)|3D, RI|--|[DHFR](https://www.chrsmrrs.com/graphkerneldatasets/DHFR.zip)|
-|**DHFR_MD**|[7,23]| 393 |2|23.87| 283.01|+|+|--|--|+ (1)|[DHFR_MD](https://www.chrsmrrs.com/graphkerneldatasets/DHFR_MD.zip)|
+|**DHFR**|[7]| 756 |2|42.43|44.54|+|--|+ (3)|3D, RI|--|[DHFR](https://www.chrsmrrs.com/graphkerneldatasets/DHFR.zip)|
+|**DHFR_MD**|[7,23]| 393 |2|23.87| 283.02|+|+|--|--|+ (1)|[DHFR_MD](https://www.chrsmrrs.com/graphkerneldatasets/DHFR_MD.zip)|
 |**ER_MD**|[7,23]| 446 |2| 21.33| 234.85 | +|+|--|--|+ (1)|[ER_MD](https://www.chrsmrrs.com/graphkerneldatasets/ER_MD.zip)|
 |**ethanol**|[36]| 455093 |R (1)|9.00|36.00|+|--|+ (6)|3D, RI|--|[ethanol](https://www.chrsmrrs.com/graphkerneldatasets/ethanol.zip)|
 |**FRANKENSTEIN**|[15]| 4337 | 2 |16.90| 17.88 |--|--|+ (780)|--|--|[FRANKENSTEIN](https://www.chrsmrrs.com/graphkerneldatasets/FRANKENSTEIN.zip)|
 |**malonaldehyde**|[36]| 893238 |R (1)|9.00|36.00|+|--|+ (6)|3D, RI|--|[malonaldehyde](https://www.chrsmrrs.com/graphkerneldatasets/malonaldehyde.zip)|
-|**MCF-7**|[28]| 27770 |2|26.39| 28.52 |+|+|--|--|--|[MCF-7](https://www.chrsmrrs.com/graphkerneldatasets/MCF-7.zip)|
-|**MCF-7H**|[28]| 27770 |2|47.30| 49.43 |+|+|--|--|--|[MCF-7H](https://www.chrsmrrs.com/graphkerneldatasets/MCF-7H.zip)|
-|**MOLT-4**|[28]| 39765 |2|26.09| 28.13 |+|+|--|--|--|[MOLT-4](https://www.chrsmrrs.com/graphkerneldatasets/MOLT-4.zip)|
-|**MOLT-4H**|[28]| 39765 |2|46.70| 48.73 |+|+|--|--|--|[MOLT-4H](https://www.chrsmrrs.com/graphkerneldatasets/MOLT-4H.zip)|
+|**MCF-7**|[28]| 27770 |2|26.40| 28.53 |+|+|--|--|--|[MCF-7](https://www.chrsmrrs.com/graphkerneldatasets/MCF-7.zip)|
+|**MCF-7H**|[28]| 27770 |2|47.31| 49.44 |+|+|--|--|--|[MCF-7H](https://www.chrsmrrs.com/graphkerneldatasets/MCF-7H.zip)|
+|**MOLT-4**|[28]| 39765 |2|26.10| 28.14 |+|+|--|--|--|[MOLT-4](https://www.chrsmrrs.com/graphkerneldatasets/MOLT-4.zip)|
+|**MOLT-4H**|[28]| 39765 |2|46.70| 48.74 |+|+|--|--|--|[MOLT-4H](https://www.chrsmrrs.com/graphkerneldatasets/MOLT-4H.zip)|
 |**Mutagenicity**|[16,20]| 4337 |2| 30.32 | 30.77 |+|+|--|--|--|[Mutagenicity](https://www.chrsmrrs.com/graphkerneldatasets/Mutagenicity.zip)|
 |**MUTAG**|[1,23]| 188 |2|17.93|19.79|+|+|--|--|--|[MUTAG](https://www.chrsmrrs.com/graphkerneldatasets/MUTAG.zip)|
 |**naphthalene**|[36]| 226256 |R (1)|18.00|127.37|+|--|+ (6)|3D, RI|--|[naphthalene](https://www.chrsmrrs.com/graphkerneldatasets/naphthalene.zip)|
 |**NCI1**|[8,9,22]| 4110 |2|29.87|32.30|+|--|--|--|--|[NCI1](https://www.chrsmrrs.com/graphkerneldatasets/NCI1.zip)|
 |**NCI109**|[8,9,22]| 4127 |2|29.68| 32.13 |+|--|--|--|--|[NCI109](https://www.chrsmrrs.com/graphkerneldatasets/NCI109.zip)|
 |**NCI-H23**|[28]| 40353 |2|26.07| 28.10 |+|+|--|--|--|[NCI-H23](https://www.chrsmrrs.com/graphkerneldatasets/NCI-H23.zip)|
-|**NCI-H23H**|[28]| 40353 |2|46.67| 48.69 |+|+|--|--|--|[NCI-H23H](https://www.chrsmrrs.com/graphkerneldatasets/NCI-H23H.zip)|
-|**OVCAR-8**|[28]| 40516 |2|26.07| 28.10 |+|+|--|--|--|[OVCAR-8](https://www.chrsmrrs.com/graphkerneldatasets/OVCAR-8.zip)|
+|**NCI-H23H**|[28]| 40353 |2|46.67| 48.70 |+|+|--|--|--|[NCI-H23H](https://www.chrsmrrs.com/graphkerneldatasets/NCI-H23H.zip)|
+|**OVCAR-8**|[28]| 40516 |2|26.08| 28.11 |+|+|--|--|--|[OVCAR-8](https://www.chrsmrrs.com/graphkerneldatasets/OVCAR-8.zip)|
 |**OVCAR-8H**|[28]| 40516 |2|46.67| 48.70 |+|+|--|--|--|[OVCAR-8H](https://www.chrsmrrs.com/graphkerneldatasets/OVCAR-8H.zip)|
-|**P388**|[28]| 41472 |2|22.11| 23.55 |+|+|--|--|--|[P388](https://www.chrsmrrs.com/graphkerneldatasets/P388.zip)|
-|**P388H**|[28]| 41472 |2|40.44| 41.88 |+|+|--|--|--|[P388H](https://www.chrsmrrs.com/graphkerneldatasets/P388H.zip)|
-|**PC-3**|[28]| 27509 |2|26.35| 28.49 |+|+|--|--|--|[PC-3](https://www.chrsmrrs.com/graphkerneldatasets/PC-3.zip)|
-|**PC-3H**|[28]| 27509 |2|47.19| 49.32 |+|+|--|--|--|[PC-3H](https://www.chrsmrrs.com/graphkerneldatasets/PC-3H.zip)|
+|**P388**|[28]| 41472 |2|22.11| 23.56 |+|+|--|--|--|[P388](https://www.chrsmrrs.com/graphkerneldatasets/P388.zip)|
+|**P388H**|[28]| 41472 |2|40.45| 41.89 |+|+|--|--|--|[P388H](https://www.chrsmrrs.com/graphkerneldatasets/P388H.zip)|
+|**PC-3**|[28]| 27509 |2|26.36| 28.49 |+|+|--|--|--|[PC-3](https://www.chrsmrrs.com/graphkerneldatasets/PC-3.zip)|
+|**PC-3H**|[28]| 27509 |2|47.20| 49.33 |+|+|--|--|--|[PC-3H](https://www.chrsmrrs.com/graphkerneldatasets/PC-3H.zip)|
 |**PTC_FM**|[2,23]| 349 |2|14.11|14.48|+|+|--|--|--|[PTC_FM](https://www.chrsmrrs.com/graphkerneldatasets/PTC_FM.zip)|
 |**PTC_FR**|[2,23]| 351 |2|14.56| 15.00|+|+|--|--|--|[PTC_FR](https://www.chrsmrrs.com/graphkerneldatasets/PTC_FR.zip)|
 |**PTC_MM**|[2,23]| 336 |2|13.97 | 14.32|+|+|--|--|--|[PTC_MM](https://www.chrsmrrs.com/graphkerneldatasets/PTC_MM.zip)|
 |**PTC_MR**|[2,23]| 344 |2|14.29| 14.69|+|+|--|--|--|[PTC_MR](https://www.chrsmrrs.com/graphkerneldatasets/PTC_MR.zip)|
 |**QM9**|[33,34,35]| 129433|R (19)|18.03|18.63|--|--|+ (16)|3D, RI|+ (4)|[QM9](https://www.chrsmrrs.com/graphkerneldatasets/QM9.zip)|
 |**salicylic_acid**|[36]| 220232 |R (1)|16.00|104.13|+|--|+ (6)|3D, RI|--|[salicylic_acid](https://www.chrsmrrs.com/graphkerneldatasets/salicylic_acid.zip)|
-|**SF-295**|[28]| 40271 |2|26.06| 28.08 |+|+|--|--|--|[SF-295](https://www.chrsmrrs.com/graphkerneldatasets/SF-295.zip)|
+|**SF-295**|[28]| 40271 |2|26.06| 28.09 |+|+|--|--|--|[SF-295](https://www.chrsmrrs.com/graphkerneldatasets/SF-295.zip)|
 |**SF-295H**|[28]| 40271 |2|46.65| 48.68 |+|+|--|--|--|[SF-295H](https://www.chrsmrrs.com/graphkerneldatasets/SF-295H.zip)|
 |**SN12C**|[28]| 40004 |2|26.08| 28.11 |+|+|--|--|--|[SN12C](https://www.chrsmrrs.com/graphkerneldatasets/SN12C.zip)|
-|**SN12CH**|[28]| 40004 |2|46.69| 48.71 |+|+|--|--|--|[SN12CH](https://www.chrsmrrs.com/graphkerneldatasets/SN12CH.zip)|
-|**SW-620**|[28]| 40532 |2|26.05| 28.08 |+|+|--|--|--|[SW-620](https://www.chrsmrrs.com/graphkerneldatasets/SW-620.zip)|
-|**SW-620H**|[28]| 40532 |2|46.62| 48.65 |+|+|--|--|--|[SW-620H](https://www.chrsmrrs.com/graphkerneldatasets/SW-620H.zip)|
+|**SN12CH**|[28]| 40004 |2|46.69| 48.72 |+|+|--|--|--|[SN12CH](https://www.chrsmrrs.com/graphkerneldatasets/SN12CH.zip)|
+|**SW-620**|[28]| 40532 |2|26.06| 28.09 |+|+|--|--|--|[SW-620](https://www.chrsmrrs.com/graphkerneldatasets/SW-620.zip)|
+|**SW-620H**|[28]| 40532 |2|46.63| 48.66 |+|+|--|--|--|[SW-620H](https://www.chrsmrrs.com/graphkerneldatasets/SW-620H.zip)|
 |**toluene**|[36]| 342791 |R (1)|15.00|96.15|+|--|+ (6)|3D, RI|--|[toluene](https://www.chrsmrrs.com/graphkerneldatasets/toluene.zip)|
 |**Tox21_AhR_training**|[24]|8169|2 |18.09|18.50|+|+|--|--|--|[Tox21_AhR_training](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AhR_training.zip)|
 |**Tox21_AhR_testing**|[24]|272|2 |22.13|23.05|+|+|--|--|--|[Tox21_AhR_testing](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AhR_testing.zip)|
 |**Tox21_AhR_evaluation**|[24]|607|2 |17.64|18.06|+|+|--|--|--|[Tox21_AhR_evaluation](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AhR_evaluation.zip)|
-|**Tox21_AR_training**|[24]|9362|2 |18.39|18.84|+|+|--|--|--|[Tox21_AR_training](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AR_training.zip)|
+|**Tox21_AR_training**|[24]|9362|2 |18.39|18.85|+|+|--|--|--|[Tox21_AR_training](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AR_training.zip)|
 |**Tox21_AR_testing**|[24]|292|2 |22.35|23.32|+|+|--|--|--|[Tox21_AR_testing](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AR_testing.zip)|
 |**Tox21_AR_evaluation**|[24]|585|2 |17.99|18.45|+|+|--|--|--|[Tox21_AR_evaluation](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AR_evaluation.zip)|
 |**Tox21_AR-LBD_training**|[24]|8599|2 |17.77|18.16|+|+|--|--|--|[Tox21_AR-LBD_training](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_AR-LBD_training.zip)|
@@ -89,12 +89,12 @@ permalink: /docs/datasets/
 |**Tox21_PPAR-gamma_training**|[24]|8184|2 |17.23|17.55|+|+|--|--|--|[Tox21_PPAR-gamma_training](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_PPAR-gamma_training.zip)|
 |**Tox21_PPAR-gamma_testing**|[24]|267|2 |22.04|22.93|+|+|--|--|--|[Tox21_PPAR-gamma_testing](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_PPAR-gamma_testing.zip)|
 |**Tox21_PPAR-gamma_evaluation**|[24]|602|2 |17.38|17.77|+|+|--|--|--|[Tox21_PPAR-gamma_evaluation](https://www.chrsmrrs.com/graphkerneldatasets/Tox21_PPAR-gamma_evaluation.zip)|
-|**UACC257**|[28]| 39988 |2|26.09| 28.12 |+|+|--|--|--|[UACC257](https://www.chrsmrrs.com/graphkerneldatasets/UACC257.zip)|
+|**UACC257**|[28]| 39988 |2|26.09| 28.13 |+|+|--|--|--|[UACC257](https://www.chrsmrrs.com/graphkerneldatasets/UACC257.zip)|
 |**UACC257H**|[28]| 39988 |2|46.68| 48.71 |+|+|--|--|--|[UACC257H](https://www.chrsmrrs.com/graphkerneldatasets/UACC257H.zip)|
 |**uracil**|[36]| 133770 |R (1)|12.00|64.44|+|--|+ (6)|3D, RI|--|[uracil](https://www.chrsmrrs.com/graphkerneldatasets/uracil.zip)|
 |**Yeast**|[28]| 79601 |2|21.54| 22.84 |+|+|--|--|--|[Yeast](https://www.chrsmrrs.com/graphkerneldatasets/Yeast.zip)|
-|**YeastH**|[28]| 79601 |2|39.44| 40.74 |+|+|--|--|--|[YeastH](https://www.chrsmrrs.com/graphkerneldatasets/YeastH.zip)|
-|**ZINC_full**|[31]| 249456 |R (1)|23.14|24.91|+|+|--|--|--|[ZINC_full](https://www.chrsmrrs.com/graphkerneldatasets/ZINC_full.zip)|
+|**YeastH**|[28]| 79601 |2|39.45| 40.75 |+|+|--|--|--|[YeastH](https://www.chrsmrrs.com/graphkerneldatasets/YeastH.zip)|
+|**ZINC_full**|[31]| 249456 |R (1)|23.15|24.90|+|+|--|--|--|[ZINC_full](https://www.chrsmrrs.com/graphkerneldatasets/ZINC_full.zip)|
 |**ZINC_test**|[31]| 5000 |R (1)|23.10|24.83|+|+|--|--|--|[ZINC_test](https://www.chrsmrrs.com/graphkerneldatasets/ZINC_test.zip)|
 |**ZINC_train**|[31]| 220011 |R (1)|23.15|24.91|+|+|--|--|--|[ZINC_train](https://www.chrsmrrs.com/graphkerneldatasets/ZINC_train.zip)|
 |**ZINC_val**|[31]| 24445 |R (1)|23.13|24.88|+|+|--|--|--|[ZINC_val](https://www.chrsmrrs.com/graphkerneldatasets/ZINC_val.zip)|
@@ -122,11 +122,11 @@ permalink: /docs/datasets/
 |**COIL-DEL**|[16,18]| 3900 |100| 21.54 | 54.24 |--|+|+ (2)|--|--|[COIL-DEL](https://www.chrsmrrs.com/graphkerneldatasets/COIL-DEL.zip)|
 |**COIL-RAG**|[16,18]| 3900 |100| 3.01 | 3.02 |--|--|+ (64)|--|+ (1)|[COIL-RAG](https://www.chrsmrrs.com/graphkerneldatasets/COIL-RAG.zip)|
 |**Cuneiform**|[25]| 267 |30|21.27|44.80|+|+|+ (3)|3D|+ (2)|[Cuneiform](https://www.chrsmrrs.com/graphkerneldatasets/Cuneiform.zip)|
-|**Fingerprint**|[16,19]| 2800 |15|5.42 | 4.42|--|--|+ (2)|2D|+ (2)|[Fingerprint](https://www.chrsmrrs.com/graphkerneldatasets/Fingerprint.zip)|
+|**Fingerprint**|[16,19]| 2149 |15|7.06 | 5.76|--|--|+ (2)|2D|+ (2)|[Fingerprint](https://www.chrsmrrs.com/graphkerneldatasets/Fingerprint.zip)|
 |**FIRSTMM_DB**|[11,12,13]| 41 |11|1377.27| 3074.10|+|--|+ (1)|--|+ (2)|[FIRSTMM_DB](https://www.chrsmrrs.com/graphkerneldatasets/FIRSTMM_DB.zip)|
 |**Letter-high**|[16]| 2250 |15| 4.67 |4.50 |--|--|+ (2)|2D|--|[Letter-high](https://www.chrsmrrs.com/graphkerneldatasets/Letter-high.zip)|
 |**Letter-low**|[16]| 2250 |15| 4.68 |3.13 |--|--|+ (2)|2D|--|[Letter-low](https://www.chrsmrrs.com/graphkerneldatasets/Letter-low.zip)|
-|**Letter-med**|[16]| 2250 |15| 4.67 |4.50 |--|--|+ (2)|2D|--|[Letter-med](https://www.chrsmrrs.com/graphkerneldatasets/Letter-med.zip)|
+|**Letter-med**|[16]| 2250 |15| 4.67 |3.21 |--|--|+ (2)|2D|--|[Letter-med](https://www.chrsmrrs.com/graphkerneldatasets/Letter-med.zip)|
 |**MSRC_9**|[13]| 221 |8|40.58| 97.94 |+|--|--|--|--|[MSRC_9](https://www.chrsmrrs.com/graphkerneldatasets/MSRC_9.zip)|
 |**MSRC_21**|[13]| 563 |20|77.52|198.32|+|--|--|--|--|[MSRC_21](https://www.chrsmrrs.com/graphkerneldatasets/MSRC_21.zip)|
 |**MSRC_21C**|[13]| 209 |20|40.28 | 96.60|+|--|--|--|--|[MSRC_21C](https://www.chrsmrrs.com/graphkerneldatasets/MSRC_21C.zip)|
@@ -138,27 +138,27 @@ permalink: /docs/datasets/
 |         |          |*Graphs*|*Classes*|*Avg. Nodes*|*Avg. Edges*|*Node Labels*|*Edge Labels*|*Node Attr.*|*Geometry*|*Edge Attr.*|
 | --- |--- | --- |---|---| ---|  :---:| :---:| :---: | :---: |  :---:|  --- |
 |**COLLAB**|[14]| 5000 |3|74.49 | 2457.78|--|--|--|--|--|[COLLAB](https://www.chrsmrrs.com/graphkerneldatasets/COLLAB.zip)|
-|**dblp_ct1**|[32]|755|2 |52.87|320.09|temporal|--|--|--|temporal|[dblp_ct1](https://www.chrsmrrs.com/graphkerneldatasets/dblp_ct1.zip)|
-|**dblp_ct2**|[32]|755|2 |52.87|320.09|temporal|--|--|--|temporal|[dblp_ct2](https://www.chrsmrrs.com/graphkerneldatasets/dblp_ct2.zip)|
+|**dblp_ct1**|[32]|755|2 |52.87|99.78|temporal|--|--|--|temporal|[dblp_ct1](https://www.chrsmrrs.com/graphkerneldatasets/dblp_ct1.zip)|
+|**dblp_ct2**|[32]|755|2 |52.87|99.78|temporal|--|--|--|temporal|[dblp_ct2](https://www.chrsmrrs.com/graphkerneldatasets/dblp_ct2.zip)|
 |**DBLP_v1**|[26]|19456|2 |10.48|19.65|+|+|--|--|--|[DBLP_v1](https://www.chrsmrrs.com/graphkerneldatasets/DBLP_v1.zip)|
 |**deezer_ego_nets**|[30]| 9629 |2|23.49| 65.25 |--|--|--|--|--|[deezer_ego_nets](https://www.chrsmrrs.com/graphkerneldatasets/deezer_ego_nets.zip)|
-|**facebook_ct1**|[32]|995|2 |95.72|269.01|temporal|--|--|--|temporal|[facebook_ct1](https://www.chrsmrrs.com/graphkerneldatasets/facebook_ct1.zip)|
-|**facebook_ct2**|[32]|995|2 |95.72|269.01|temporal|--|--|--|temporal|[facebook_ct2](https://www.chrsmrrs.com/graphkerneldatasets/facebook_ct2.zip)|
+|**facebook_ct1**|[32]|995|2 |95.72|101.72|temporal|--|--|--|temporal|[facebook_ct1](https://www.chrsmrrs.com/graphkerneldatasets/facebook_ct1.zip)|
+|**facebook_ct2**|[32]|995|2 |95.72|101.72|temporal|--|--|--|temporal|[facebook_ct2](https://www.chrsmrrs.com/graphkerneldatasets/facebook_ct2.zip)|
 |**github_stargazers**|[30]| 12725 |2|113.79| 234.64 |--|--|--|--|--|[github_stargazers](https://www.chrsmrrs.com/graphkerneldatasets/github_stargazers.zip)|
-|**highschool_ct1**|[32]|180|2 |52.32|544.81|temporal|--|--|--|temporal|[highschool_ct1](https://www.chrsmrrs.com/graphkerneldatasets/highschool_ct1.zip)|
-|**highschool_ct2**|[32]|180|2 |52.32|544.81|temporal|--|--|--|temporal|[highschool_ct2](https://www.chrsmrrs.com/graphkerneldatasets/highschool_ct2.zip)|
+|**highschool_ct1**|[32]|180|2 |52.32|112.08|temporal|--|--|--|temporal|[highschool_ct1](https://www.chrsmrrs.com/graphkerneldatasets/highschool_ct1.zip)|
+|**highschool_ct2**|[32]|180|2 |52.32|112.08|temporal|--|--|--|temporal|[highschool_ct2](https://www.chrsmrrs.com/graphkerneldatasets/highschool_ct2.zip)|
 |**IMDB-BINARY**|[14]| 1000 |2| 19.77 | 96.53 |--|--|--||----|[IMDB-BINARY](https://www.chrsmrrs.com/graphkerneldatasets/IMDB-BINARY.zip)|
 |**IMDB-MULTI**|[14]| 1500 |3| 13.00 | 65.94 |--|--|--||----|[IMDB-MULTI](https://www.chrsmrrs.com/graphkerneldatasets/IMDB-MULTI.zip)|
-|**infectious_ct1**|[32]|200|2 |50|459.72|temporal|--|--|--|temporal|[infectious_ct1](https://www.chrsmrrs.com/graphkerneldatasets/infectious_ct1.zip)|
-|**infectious_ct2**|[32]|200|2 |50|459.72|temporal|--|--|--|temporal|[infectious_ct2](https://www.chrsmrrs.com/graphkerneldatasets/infectious_ct2.zip)|
-|**mit_ct1**|[32]|97|2 |20|1469.15|temporal|--|--|--|temporal|[mit_ct1](https://www.chrsmrrs.com/graphkerneldatasets/mit_ct1.zip)|
-|**mit_ct2**|[32]|97|2 |20|1469.15|temporal|--|--|--|temporal|[mit_ct2](https://www.chrsmrrs.com/graphkerneldatasets/mit_ct2.zip)|
+|**infectious_ct1**|[32]|200|2 |50|125.98|temporal|--|--|--|temporal|[infectious_ct1](https://www.chrsmrrs.com/graphkerneldatasets/infectious_ct1.zip)|
+|**infectious_ct2**|[32]|200|2 |50|125.98|temporal|--|--|--|temporal|[infectious_ct2](https://www.chrsmrrs.com/graphkerneldatasets/infectious_ct2.zip)|
+|**mit_ct1**|[32]|97|2 |20|36.61|temporal|--|--|--|temporal|[mit_ct1](https://www.chrsmrrs.com/graphkerneldatasets/mit_ct1.zip)|
+|**mit_ct2**|[32]|97|2 |20|36.61|temporal|--|--|--|temporal|[mit_ct2](https://www.chrsmrrs.com/graphkerneldatasets/mit_ct2.zip)|
 |**REDDIT-BINARY**|[14]| 2000 |2| 429.63| 497.75 |--|--|--|--|--|[REDDIT-BINARY](https://www.chrsmrrs.com/graphkerneldatasets/REDDIT-BINARY.zip)|
 |**REDDIT-MULTI-5K**|[14]| 4999 | 5 |508.52 | 594.87 |--|--|--|--|--|[REDDIT-MULTI-5K](https://www.chrsmrrs.com/graphkerneldatasets/REDDIT-MULTI-5K.zip)|
 |**REDDIT-MULTI-12K**|[14]| 11929 | 11 | 391.41 | 456.89 |--|--|--|--|--|[REDDIT-MULTI-12K](https://www.chrsmrrs.com/graphkerneldatasets/REDDIT-MULTI-12K.zip)|
 |**reddit_threads**|[30]| 203088 |2|23.93| 24.99 |--|--|--|--|--|[reddit_threads](https://www.chrsmrrs.com/graphkerneldatasets/reddit_threads.zip)|
-|**tumblr_ct1**|[32]|373|2 |53.11|199.78|temporal|--|--|--|temporal|[tumblr_ct1](https://www.chrsmrrs.com/graphkerneldatasets/tumblr_ct1.zip)|
-|**tumblr_ct2**|[32]|373|2 |53.11|199.78|temporal|--|--|--|temporal|[tumblr_ct2](https://www.chrsmrrs.com/graphkerneldatasets/tumblr_ct2.zip)|
+|**tumblr_ct1**|[32]|373|2 |53.11|71.63|temporal|--|--|--|temporal|[tumblr_ct1](https://www.chrsmrrs.com/graphkerneldatasets/tumblr_ct1.zip)|
+|**tumblr_ct2**|[32]|373|2 |53.11|71.63|temporal|--|--|--|temporal|[tumblr_ct2](https://www.chrsmrrs.com/graphkerneldatasets/tumblr_ct2.zip)|
 |**twitch_egos**|[30]| 127094 |2|29.67| 86.59 |--|--|--|--|--|[twitch_egos](https://www.chrsmrrs.com/graphkerneldatasets/twitch_egos.zip)|
 |**TWITTER-Real-Graph-Partial**|[26]|144033|2 |4.03|4.98|+|--|--|--|+ (1)|[TWITTER-Real-Graph-Partial](https://www.chrsmrrs.com/graphkerneldatasets/TWITTER-Real-Graph-Partial.zip)|
 


### PR DESCRIPTION
Fixes all errors in the `Graphs`, `Avg. Nodes` and `Avg. Edges` columns of the index table. 

Some of them were small rounding inaccuracies and some were severe. For example, `DHFR` has 756 graphs instead of 437, and `mit_ct1`/`2` has ~36, not ~1469 edges on average.